### PR TITLE
add a comment to bump about branch protections

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -1,3 +1,4 @@
+# This action requires that the branch protection for main do not require a pull request before merging.
 name: Update file on PR merge
 on:
   pull_request:


### PR DESCRIPTION
Testing bumpversion again after removing the branch protection.   This is documented in 
https://stackoverflow.com/questions/74128344/github-protected-branch-hook-declined-even-with-allow-force-pushes
