### PR TITLE
Use different var for nc/nf-config --includedir outputs

### DIFF
--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -46,9 +46,9 @@ if(NetCDF_C_CONFIG_EXECUTABLE)
                     OUTPUT_VARIABLE DEFAULT_C_INCLUDE_DIR
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
   execute_process(COMMAND ${NetCDF_C_CONFIG_EXECUTABLE} --libs
-                    OUTPUT_VARIABLE libs
+                    OUTPUT_VARIABLE clibs
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
-  if (flibs)
+  if (clibs)
     set(NetCDF_C_LIBRARIES ${libs} CACHE STRING "NetCDF libraries (or linking flags)")
     set(AUTODETECTED_NetCDF_C ON)
   endif()

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -65,7 +65,7 @@ else()
 endif()
 
 find_path(NetCDF_Fortran_INCLUDE_DIRS netcdf.mod
-  HINTS "${DEFAULT_Fortran_INCLUDE_DIR}" "$ENV{NetCDF_Fortran_INCLDE_DIRS}" "$ENV{CONDA_PREFIX}/Library/include"
+  HINTS "${DEFAULT_Fortran_INCLUDE_DIR}" "$ENV{NetCDF_Fortran_INCLUDE_DIRS}" "$ENV{CONDA_PREFIX}/Library/include"
   DOC "NetCDF Fortran include directories")
 
 find_library(NetCDF_Fortran_LIBRARY NAMES ${DEFAULT_LIBRARY_NAME}
@@ -73,7 +73,7 @@ find_library(NetCDF_Fortran_LIBRARY NAMES ${DEFAULT_LIBRARY_NAME}
             DOC "NetCDF libraries (or linking flags)")
 
 find_path(NetCDF_C_INCLUDE_DIRS netcdf.h
-  HINTS "${DEFAULT_C_INCLUDE_DIR}" "$ENV{NetCDF_C_INCLDE_DIRS}" "$ENV{CONDA_PREFIX}/Library/include"
+  HINTS "${DEFAULT_C_INCLUDE_DIR}" "$ENV{NetCDF_C_INCLUDE_DIRS}" "$ENV{CONDA_PREFIX}/Library/include"
   DOC "NetCDF C include directories")
 
 find_library(NetCDF_C_LIBRARY NAMES ${DEFAULT_LIBRARY_NAME}

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -18,7 +18,7 @@ if(NetCDF_Fortran_CONFIG_EXECUTABLE)
     # Note that if the process fails (as e.g. on Windows), the output variables
     # will remain empty
   execute_process(COMMAND ${NetCDF_Fortran_CONFIG_EXECUTABLE} --includedir
-                    OUTPUT_VARIABLE DEFAULT_INCLUDE_DIR
+                    OUTPUT_VARIABLE DEFAULT_Fortran_INCLUDE_DIR
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
   execute_process(COMMAND ${NetCDF_Fortran_CONFIG_EXECUTABLE} --flibs
                     OUTPUT_VARIABLE flibs
@@ -43,7 +43,7 @@ if(NetCDF_C_CONFIG_EXECUTABLE)
     # Note that if the process fails (as e.g. on Windows), the output variables
     # will remain empty
   execute_process(COMMAND ${NetCDF_C_CONFIG_EXECUTABLE} --includedir
-                    OUTPUT_VARIABLE DEFAULT_INCLUDE_DIR
+                    OUTPUT_VARIABLE DEFAULT_C_INCLUDE_DIR
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
   execute_process(COMMAND ${NetCDF_C_CONFIG_EXECUTABLE} --libs
                     OUTPUT_VARIABLE libs
@@ -65,7 +65,7 @@ else()
 endif()
 
 find_path(NetCDF_Fortran_INCLUDE_DIRS netcdf.mod
-  HINTS "${DEFAULT_INCLUDE_DIR}" "$ENV{NetCDF_Fortran_INCLDE_DIRS}" "$ENV{CONDA_PREFIX}/Library/include"
+  HINTS "${DEFAULT_Fortran_INCLUDE_DIR}" "$ENV{NetCDF_Fortran_INCLDE_DIRS}" "$ENV{CONDA_PREFIX}/Library/include"
   DOC "NetCDF Fortran include directories")
 
 find_library(NetCDF_Fortran_LIBRARY NAMES ${DEFAULT_LIBRARY_NAME}
@@ -73,7 +73,7 @@ find_library(NetCDF_Fortran_LIBRARY NAMES ${DEFAULT_LIBRARY_NAME}
             DOC "NetCDF libraries (or linking flags)")
 
 find_path(NetCDF_C_INCLUDE_DIRS netcdf.h
-  HINTS "${DEFAULT_INCLUDE_DIR}" "$ENV{NetCDF_C_INCLDE_DIRS}" "$ENV{CONDA_PREFIX}/Library/include"
+  HINTS "${DEFAULT_C_INCLUDE_DIR}" "$ENV{NetCDF_C_INCLDE_DIRS}" "$ENV{CONDA_PREFIX}/Library/include"
   DOC "NetCDF C include directories")
 
 find_library(NetCDF_C_LIBRARY NAMES ${DEFAULT_LIBRARY_NAME}


### PR DESCRIPTION
Fix some issues in `FindNetCDF.cmake`:
 - use different vars for `nc/nf-config --includedirs` outputs
 - fix typo `INCLDE`->`INCLUDE`
 - fix libs var name (was using flibs for C libraries)

Fixes #9 