### PR TITLE
Repeat ENV sub-option for all env vars in find_program

### DIFF
--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -1,13 +1,13 @@
 # First try to locate nf-config.
 find_program(NetCDF_Fortran_CONFIG_EXECUTABLE
     NAMES nf-config
-    HINTS ENV NetCDF_ROOT NetCDF_Fortran_ROOT
+    HINTS ENV NetCDF_ROOT ENV NetCDF_Fortran_ROOT
     PATH_SUFFIXES bin Bin
     DOC "NetCDF config program. Used to detect NetCDF Fortran include directory and linker flags." )
 mark_as_advanced(NetCDF_Fortran_CONFIG_EXECUTABLE)
 find_program(NetCDF_C_CONFIG_EXECUTABLE
     NAMES nc-config
-    HINTS ENV NetCDF_ROOT NetCDF_C_ROOT
+    HINTS ENV NetCDF_ROOT ENV NetCDF_C_ROOT
     PATH_SUFFIXES bin Bin
     DOC "NetCDF config program. Used to detect NetCDF C include directory and linker flags." )
 mark_as_advanced(NetCDF_C_CONFIG_EXECUTABLE)


### PR DESCRIPTION
ENV only applies to *the next* entry, not to all the entries in the HINTS list. If we have 2+ env vars, we need to repeat the ENV sup-option in front of each of them.