### PR TITLE
Improve CMake detection of whether NetCDF is found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ endforeach ()
 
 # Try to find NetCDF dependency. Try standard find_package first.
 find_package(NetCDF QUIET COMPONENTS C Fortran)
-if (NetCDF_FOUND)
+if (NetCDF_C_FOUND AND NetCDF_Fortran_FOUND)
   if(TARGET NetCDF::NetCDF_Fortran)
     set(CPRNC_NETCDF_FORTRAN_LIB NetCDF::NetCDF_Fortran)
     set(CPRNC_NETCDF_C_LIB       NetCDF::NetCDF_C)


### PR DESCRIPTION
Without this fix, the build on my Mac finds a netCDFConfig.cmake file (rather than a FindNetCDF.cmake file) that causes entrance into the wrong block.

Resolves ESMCI/cprnc#29

Fix suggested by @bartgol 